### PR TITLE
Disable blanket automerge rule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,3 +1,4 @@
 {
-  "extends": ["github>balena-io/renovate-config"]
+  "extends": ["github>balena-io/renovate-config"],
+  "automerge": false
 }


### PR DESCRIPTION
Specific updateType automerge settings should be inherited from balena-io/renovate-config.

Change-type: patch