### PR TITLE
yocto-build-env/Dockerfile: Update to Ubuntu 22.04

### DIFF
--- a/yocto-build-env/Dockerfile
+++ b/yocto-build-env/Dockerfile
@@ -1,7 +1,7 @@
-# yocto build environment, forked from
-# https://github.com/balena-os/balena-yocto-scripts/blob/45e32821ac6e3efba81e24a21e417a375da5e154/automation/Dockerfile_yocto-build-env
+# yocto build environment, adapted from
+# https://github.com/balena-os/balena-yocto-scripts/blob/a880342e40fe05d00a0f1cf2582a0699921152e0/automation/Dockerfile_yocto-build-env
 
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -10,9 +10,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
     build-essential chrpath curl diffstat gcc-multilib gawk git-core locales zstd liblz4-tool \
-    texinfo unzip wget xterm cpio file python python3 openssh-client iputils-ping iproute2 \
+    texinfo unzip wget xterm cpio file python3 openssh-client iputils-ping iproute2 \
     python3-distutils python3-pip python3-pexpect python3-git python3-jinja2 python3-subunit \
-    gawk socat xz-utils libegl1-mesa libsdl1.2-dev pylint3 mesa-common-dev debianutils vim sharutils rsync \
+    gawk socat xz-utils libegl1-mesa libsdl1.2-dev pylint mesa-common-dev debianutils vim sharutils rsync \
     mc byobu bash-completion pigz less nano \
     && rm -rf /var/lib/apt/lists/*
 
@@ -28,17 +28,8 @@ RUN apt-get update \
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-RUN curl --silent https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
-
-ARG NODE_VERSION=node_8.x
-
-RUN echo "deb https://deb.nodesource.com/$NODE_VERSION $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/nodesource.list \
-    && echo "deb-src https://deb.nodesource.com/$NODE_VERSION $(lsb_release -cs) main" | tee -a /etc/apt/sources.list.d/nodesource.list
-
-# hadolint ignore=DL3008
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends jq nodejs \
-    && rm -rf /var/lib/apt/lists/*
+# hadolint ignore=DL3008,DL3015
+RUN apt-get update && apt-get install -y jq nodejs npm sudo && rm -rf /var/lib/apt/lists/*
 
 # Additional host packages required by various BSP layers
 # hadolint ignore=DL3008
@@ -48,21 +39,8 @@ RUN apt-get update \
 
 # Install docker matching the balena-engine version
 # https://docs.docker.com/engine/install/ubuntu/
-# hadolint ignore=DL3008
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends iptables procps e2fsprogs xfsprogs xz-utils kmod \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
-    $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
-
-ARG DOCKER_VERSION="5:19.03.13~3-0~ubuntu-bionic"
-
-# hadolint ignore=DL3008
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends docker-ce=${DOCKER_VERSION} docker-ce-cli=${DOCKER_VERSION} containerd.io \
-    && rm -rf /var/lib/apt/lists/*
+# hadolint ignore=DL3008,DL3015
+RUN apt-get update && apt-get install -y iptables procps e2fsprogs xfsprogs xz-utils git kmod apt-transport-https ca-certificates curl gnupg lsb-release docker.io && rm -rf /var/lib/apt/lists/*
 
 VOLUME /var/lib/docker
 


### PR DESCRIPTION
This update is based on
https://github.com/balena-os/balena-yocto-scripts/commit/e027c512dbcf801a66a4bb4da15639ca67eedd2e

Recently balena-yocto-scripts have been updated to use Ubuntu 22.04, let's follow suit and use this on the misc servers too.

Internal thread: https://balena.zulipchat.com/#narrow/stream/360838-balena-io.2Fos.2Fdevices/topic/Jenkins.20meta-balena.20builds/near/448347500

Change-type: patch