### PR TITLE
Patch: add aethernet to misc1/2 users

### DIFF
--- a/yocto-build-env/s6-overlay/scripts/addusers
+++ b/yocto-build-env/s6-overlay/scripts/addusers
@@ -19,6 +19,7 @@ user_ids="
     rcooke-warwick:1009
     jaomaloy:1010
     shaunmulligan:1011
+    aethernet:1012
 "
 
 fetch_ssh_keys() {


### PR DESCRIPTION
Add Aethernet as a valid user for yocto work